### PR TITLE
fix: grid layout dose not update in Shiny app (#42)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r3dmol
 Title: Create Interactive 3D Visualizations of Molecular Data
-Version: 0.1.3
+Version: 0.2.0
 Authors@R: 
     c(person(given = "Wei",
            family = "Su",

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ See [Using Buttons in `{r3dmol}`](https://swsoyee.github.io/r3dmol/articles/usin
 * Fix the bug that surface cannot be rendered correctly when using `m_png()`
 with `m_add_surface()` at the same time, and optimize the default image size 
 setting of `m_png()` ([#35](https://github.com/swsoyee/r3dmol/issues/35)).
+* Fix grid layout dose not update in Shiny app ([#42](https://github.com/swsoyee/r3dmol/issues/42), [#44](https://github.com/swsoyee/r3dmol/issues/44))
 
 ### Other
 


### PR DESCRIPTION
Example code to test the behavior.
```r
library(shiny)
library(r3dmol)

ui <- fluidPage(
  sidebarLayout(
    sidebarPanel(
      selectInput("selected_id", "Choose a PDB ID:", choices=c("3G5X","7A2A","5IJ5")),
    ),
    mainPanel(
      ## Choose multi or individual, but not both at the same time
      r3dmolOutput(outputId = "structure_multi"),
      r3dmolOutput(outputId = "structure_individual"),
    )
  )
)

server <- function(input, output, session) {
  
  output$structure_individual <- renderR3dmol({
    r3dmol() %>%
      m_add_model(data = m_fetch_pdb(input$selected_id)) %>%
      m_zoom_to() %>%
      m_set_style(style = m_style_cartoon(color = "spectrum"))
  })
  
  output$structure_multi <- renderR3dmol({
    m1 <- r3dmol() %>%
      m_add_model(data = m_fetch_pdb(input$selected_id)) %>%
      m_zoom_to()
    
    m2 <- m1 %>%
      m_set_style(style = m_style_cartoon(color = "spectrum"))
    
    m3 <- m1 %>%
      m_set_style(style = m_style_stick())
    
    m4 <- m1 %>%
      m_set_style(style = m_style_sphere())
    
    grid <- m_grid(
      viewer = list(m1, m2, m3, m4),
      control_all = TRUE,
      viewer_config = m_viewer_spec(
        backgroundColor = "black"
      )
    )
    grid$elementId <- NULL # suppress the `Shiny doesn't use them` warning
    grid
  })
}

shinyApp(ui, server)
```

<img width="1185" alt="2021-09-17 00 41 32" src="https://user-images.githubusercontent.com/20528423/133643094-8b56e455-3074-42cb-8b65-626b1563d94f.png">
<img width="1186" alt="2021-09-17 00 41 44" src="https://user-images.githubusercontent.com/20528423/133643111-ead406ca-85b7-437d-957e-c3489e42aa2e.png">
